### PR TITLE
ci: pin nightly workflow actions to SHAs and scope its token

### DIFF
--- a/.github/workflows/nightly-upstream-upgrade.yml
+++ b/.github/workflows/nightly-upstream-upgrade.yml
@@ -6,22 +6,26 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   upgrade:
     runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
       - run: |
           brew install gpatch coreutils
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
       - run: mise run release:prepare-upstream-pr
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           commit-message: Upgrade AeroSpace upstream
           branch: bot/upgrade-aerospace


### PR DESCRIPTION
The nightly upstream-upgrade job runs three third-party actions by mutable tag while holding a `contents: write` token. If one of those action repos is compromised or a tag is repointed, the malicious version runs with a token that can push to `main`.

- Pin `actions/checkout` (v6.1.0), `jdx/mise-action` (v4.2.1) and `peter-evans/create-pull-request` (v6.1.0) to full commit SHAs.
- Default the workflow token to `contents: read`, and grant `contents`/`pull-requests: write` only on the `upgrade` job that needs it.
- Set `persist-credentials: false` on checkout so the token is not left in `.git/config` for the later `brew`/`mise` steps.

Same actions and versions as today, just pinned — no change to the upgrade behavior. `create-pull-request` keeps the write scopes it needs at the job level.
