### PR TITLE
Feature: Smart Gaps, Floating Window Resizing Keys, Center Floating Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `[single-window-gaps]` config table: an optional gaps override applied when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full `gaps` grammar, including per-monitor arrays. An empty table means zero gaps.
+- `resize` now works on floating windows, which previously exited with an error. The window's center stays fixed, so growing expands it on all four sides and shrinking pulls it in on all four sides. `smart` and `smart-opposite` resize both axes together, since a floating window has no enclosing split to read an orientation from. Sizes are clamped to the monitor's visible area and to a 100pt minimum.
+- Starter config binds per-axis resizing: `alt--`/`alt-=` for width and `alt-_`/`alt-+` for height. This replaces the previous `resize smart` bindings on `alt--`/`alt-=`.
+
+### Fixed
+
+- `resize` on a tiling window with no enclosing container on the requested axis no longer reports the misleading "doesn't support floating windows" error, and macOS minimized/fullscreen/hidden-app windows now get their own message.
 
 ## [0.3.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `[single-window-gaps]` config table: an optional gaps override applied when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full `gaps` grammar, including per-monitor arrays. An empty table means zero gaps.
 
+### Changed
+
+- `layout floating` now centers the window on its monitor at 62.5% of the monitor's visible area on each axis, instead of leaving it at whatever frame the tiling layout happened to give it. A window popped out of the tree now lands somewhere usable regardless of where it was tiled. This replaces the previous behavior of restoring the window's last floating size.
+
 ## [0.3.0] - 2026-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Current `Hyprspace` patches are based on AeroSpace v0.21.1-Beta
 
+## [Unreleased]
+
+### Added
+
+- `[single-window-gaps]` config table: an optional gaps override applied when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full `gaps` grammar, including per-monitor arrays. An empty table means zero gaps.
+
 ## [0.3.0] - 2026-07-06
 
 ### Changed

--- a/artifacts/configs/hyprspace-config.toml
+++ b/artifacts/configs/hyprspace-config.toml
@@ -68,8 +68,14 @@ alt-shift-space = 'layout floating tiling'
 alt-shift-semicolon = 'mode service'
 alt-shift-slash = 'layout tiles horizontal vertical'
 alt-shift-comma = 'layout accordion horizontal vertical'
-alt-minus = 'resize smart -50'
-alt-equal = 'resize smart +50'
+# Resize the focused window. On a popped-out (floating) window these resize around
+# its center, so it grows and shrinks evenly on all sides.
+#   alt -/=  (minus/equal)       width
+#   alt _/+  (shift minus/equal) height
+alt-minus = 'resize width -50'
+alt-equal = 'resize width +50'
+alt-shift-minus = 'resize height -50'
+alt-shift-equal = 'resize height +50'
 alt-f = 'fullscreen'
 alt-cmd-f = 'macos-native-fullscreen'
 

--- a/docs/patches.md
+++ b/docs/patches.md
@@ -63,6 +63,9 @@ The active stack is the ordered list in `patches/series`. Each patch should prov
 - `hyprspace/open-terminal.patch`
   **open terminal** — Adds open-terminal command, which opens Ghostty or Terminal.app running a specified command via AppleScript; --new forces a fresh app instance.
 
+- `hyprspace/single-window-gaps.patch`
+  **single window gaps** — Adds an optional [single-window-gaps] config table used when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full Gaps grammar including per-monitor arrays.
+
 ## Patch files not currently in `patches/series`
 
 - `hyprspace/build-release-restore-generated-files.patch`

--- a/docs/patches.md
+++ b/docs/patches.md
@@ -66,6 +66,9 @@ The active stack is the ordered list in `patches/series`. Each patch should prov
 - `hyprspace/single-window-gaps.patch`
   **single window gaps** — Adds an optional [single-window-gaps] config table used when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full Gaps grammar including per-monitor arrays.
 
+- `hyprspace/resize-floating-windows.patch`
+  **resize floating windows** — Adds floating window support to the resize command, resizing around the window center.
+
 ## Patch files not currently in `patches/series`
 
 - `hyprspace/build-release-restore-generated-files.patch`

--- a/docs/patches.md
+++ b/docs/patches.md
@@ -66,6 +66,9 @@ The active stack is the ordered list in `patches/series`. Each patch should prov
 - `hyprspace/single-window-gaps.patch`
   **single window gaps** — Adds an optional [single-window-gaps] config table used when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full Gaps grammar including per-monitor arrays.
 
+- `hyprspace/center-floated-window.patch`
+  **center floated window** — Centers a window on its monitor at a default size when it is popped out to floating.
+
 ## Patch files not currently in `patches/series`
 
 - `hyprspace/build-release-restore-generated-files.patch`

--- a/patches/hyprspace/center-floated-window.patch
+++ b/patches/hyprspace/center-floated-window.patch
@@ -1,0 +1,88 @@
+# Summary: Centers a window on its monitor at a default size when it is popped out to floating.
+
+diff --git a/Sources/AppBundle/command/impl/LayoutCommand.swift b/Sources/AppBundle/command/impl/LayoutCommand.swift
+--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
++++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
+@@ -76,10 +76,35 @@
+                 guard let window = target.windowOrNil else { return .fail(io.err(noWindowIsFocused)) }
+                 let workspace = target.workspace
+                 window.bindAsFloatingWindow(to: workspace)
+-                if let size = window.lastFloatingSize { window.setAxFrame(nil, size) }
++                floatWindowInMonitorCenter(window, fallbackMonitor: workspace.workspaceMonitor)
+                 return .succ
+         }
+     }
++}
++
++/// Fraction of the monitor's visible area a freshly popped-out window covers on each axis.
++private let floatingWindowMonitorFraction: CGFloat = 0.625
++
++/// Place a newly floated window in the middle of its monitor at a predictable default size.
++///
++/// A window that was just popped out of the tiling tree keeps whatever frame the tiling layout gave
++/// it, which is rarely a sensible floating frame. Centering it makes `layout floating` land the
++/// window somewhere usable regardless of where it was tiled.
++@MainActor private func floatWindowInMonitorCenter(_ window: Window, fallbackMonitor: Monitor) {
++    let rect = (window.nodeMonitor ?? fallbackMonitor).visibleRect
++    let size = CGSize(
++        width: rect.width * floatingWindowMonitorFraction,
++        height: rect.height * floatingWindowMonitorFraction,
++    )
++    let topLeft = CGPoint(
++        x: rect.minX + (rect.width - size.width) / 2,
++        y: rect.minY + (rect.height - size.height) / 2,
++    )
++    // An explicit placement supersedes a pending `fullscreen`, which would otherwise overwrite the
++    // frame on the next layout pass.
++    window.isFullscreen = false
++    window.setAxFrame(topLeft, size)
++    window.lastFloatingSize = size
+ }
+ 
+ @MainActor private func changeTilingLayout(
+
+diff --git a/Sources/AppBundleTests/command/LayoutCommandTest.swift b/Sources/AppBundleTests/command/LayoutCommandTest.swift
+--- a/Sources/AppBundleTests/command/LayoutCommandTest.swift
++++ b/Sources/AppBundleTests/command/LayoutCommandTest.swift
+@@ -169,6 +169,26 @@
+         assertEquals(focus.windowOrNil?.windowId, 1)
+     }
+ 
++    func testTilingToFloating_centersWindowAtDefaultSize() async {
++        let workspace = Workspace.get(byName: name)
++        var window: TestWindow!
++        workspace.rootTilingContainer.apply {
++            window = TestWindow.new(id: 1, parent: $0)
++            assertEquals(window.focusWindow(), true)
++        }
++
++        await parseCommand("layout floating").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let monitor = workspace.workspaceMonitor.visibleRect
++        let rect = try? await window.getAxRect(.nonCancellable)
++        // Covers 62.5% of the monitor's visible area on each axis
++        assertEquals(rect?.size, CGSize(width: monitor.width * 0.625, height: monitor.height * 0.625))
++        // and sits in the middle of it
++        assertTrue(abs((rect?.center.x ?? 0) - monitor.center.x) < 1)
++        assertTrue(abs((rect?.center.y ?? 0) - monitor.center.y) < 1)
++        assertEquals(window.lastFloatingSize, rect?.size)
++    }
++
+     func testFloatingToTiling() async {
+         let workspace = Workspace.get(byName: name)
+         workspace.floatingWindowsContainer.apply {
+
+diff --git a/docs/aerospace-layout.adoc b/docs/aerospace-layout.adoc
+--- a/docs/aerospace-layout.adoc
++++ b/docs/aerospace-layout.adoc
+@@ -52,6 +52,10 @@
+ * `tiling|floating` - Toggle between floating/tiling mode
+ +
+ If several `<target-layout>` are supplied, then the first one that doesn't describe the currently active layout is applied.
+++
++Switching a window to `floating` centers it on its monitor at 62.5% of the monitor's visible area on
++each axis, instead of leaving it at whatever frame the tiling layout gave it. Use
++`aerospace resize` to adjust it from there, or `aerospace position` for a different placement.
+ 
+ // =========================================================== Examples
+ include::./util/conditional-examples-header.adoc[]

--- a/patches/hyprspace/resize-floating-windows.patch
+++ b/patches/hyprspace/resize-floating-windows.patch
@@ -1,0 +1,236 @@
+# Summary: Adds floating window support to the resize command, resizing around the window center.
+
+diff --git a/Sources/AppBundle/command/impl/ResizeCommand.swift b/Sources/AppBundle/command/impl/ResizeCommand.swift
+--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
++++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
+@@ -5,12 +5,25 @@
+     let args: ResizeCmdArgs
+     /*conforms*/ let shouldResetClosedWindowsCache = true
+ 
+-    func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
++    func run(_ env: CmdEnv, _ io: CmdIo) async -> BinaryExitCode {
+         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
++        guard let window = target.windowOrNil else { return .fail(io.err(noWindowIsFocused)) }
+ 
+-        let candidates = target.windowOrNil?.parentsWithSelf
++        switch window.windowParentCases {
++            case .floatingWindowsContainer:
++                return await resizeFloatingWindow(window, args.dimension.val, args.units.val, io)
++            case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer, .macosHiddenAppsWindowsContainer:
++                let msg = "Can't resize macOS minimized, fullscreen windows or windows of hidden apps. " +
++                    "This behavior is subject to change"
++                return .fail(io.err(msg))
++            case .macosPopupWindowsContainer, .unbound:
++                return .fail(io.err(bugPrompt()))
++            case .tilingContainer:
++                break // Tiling windows are resized by redistributing weights below
++        }
++
++        let candidates = window.parentsWithSelf
+             .filter { ($0.parent as? TilingContainer)?.layout == .tiles }
+-            ?? []
+ 
+         let orientation: Orientation?
+         let parent: TilingContainer?
+@@ -34,7 +47,7 @@
+                 parent = node?.parent as? TilingContainer
+         }
+         guard let parent else {
+-            return .fail(io.err("resize command doesn't support floating windows yet https://github.com/nikitabobko/AeroSpace/issues/9"))
++            return .fail(io.err("The window isn't enclosed in a 'tiles' container with the requested orientation"))
+         }
+         guard let orientation else { return .fail }
+         guard let node else { return .fail }
+@@ -53,3 +66,63 @@
+         return .succ
+     }
+ }
++
++/// Floating windows aren't sized by the tiling tree, so their frame is set directly.
++///
++/// The window's center is preserved: growing expands it on all sides, shrinking pulls it in on all
++/// sides. That keeps repeated resizes stable instead of walking the window toward one corner.
++@MainActor
++private func resizeFloatingWindow(
++    _ window: Window,
++    _ dimension: ResizeCmdArgs.Dimension,
++    _ units: ResizeCmdArgs.Units,
++    _ io: CmdIo,
++) async -> BinaryExitCode {
++    // The live frame is the source of truth. lastFloatingSize goes stale as soon as the window is
++    // resized with the mouse, since mouse resize is a no-op for floating windows in the model.
++    guard let rect = try? await window.getAxRect(.nonCancellable) else {
++        return .fail(io.err("Can't get the current frame of window \(window.windowId)"))
++    }
++
++    func resolve(_ current: CGFloat) -> CGFloat {
++        switch units {
++            case .set(let unit): CGFloat(unit)
++            case .add(let unit): current + CGFloat(unit)
++            case .subtract(let unit): current - CGFloat(unit)
++        }
++    }
++
++    var width = rect.width
++    var height = rect.height
++    switch dimension {
++        case .width: width = resolve(width)
++        case .height: height = resolve(height)
++        // A floating window has no enclosing split for 'smart' to read an orientation from, so both
++        // smart variants resize the window as a whole.
++        case .smart, .smartOpposite:
++            width = resolve(width)
++            height = resolve(height)
++    }
++
++    let monitorRect = (window.nodeMonitor ?? mainMonitor).visibleRect
++    width = width.coerce(in: minFloatingWindowSize ... max(minFloatingWindowSize, monitorRect.width))
++    height = height.coerce(in: minFloatingWindowSize ... max(minFloatingWindowSize, monitorRect.height))
++
++    let center = rect.center
++    let topLeft = CGPoint(
++        x: (center.x - width / 2).coerce(in: monitorRect.minX ... max(monitorRect.minX, monitorRect.maxX - width)),
++        y: (center.y - height / 2).coerce(in: monitorRect.minY ... max(monitorRect.minY, monitorRect.maxY - height)),
++    )
++    let size = CGSize(width: width, height: height)
++
++    // An explicit resize supersedes a pending `fullscreen`, which would otherwise overwrite the frame
++    // on the next layout pass.
++    window.isFullscreen = false
++    window.setAxFrame(topLeft, size)
++    window.lastFloatingSize = size
++    return .succ
++}
++
++/// Apps enforce their own AX minimum size. This only stops a floating window from being driven to
++/// something degenerate by repeated shrinking.
++private let minFloatingWindowSize: CGFloat = 100
+
+diff --git a/Sources/AppBundleTests/command/ResizeCommandTest.swift b/Sources/AppBundleTests/command/ResizeCommandTest.swift
+--- a/Sources/AppBundleTests/command/ResizeCommandTest.swift
++++ b/Sources/AppBundleTests/command/ResizeCommandTest.swift
+@@ -163,4 +163,102 @@
+         let result = await parseCommand("resize width +2").cmdOrDie.run(.defaultEnv, .emptyStdin)
+         assertEquals(result.exitCode.rawValue, 2)
+     }
++
++    // MARK: floating windows
++
++    @MainActor
++    private func newFloatingWindow() -> TestWindow {
++        let window = TestWindow.new(
++            id: 1,
++            parent: Workspace.get(byName: name).floatingWindowsContainer,
++            rect: Rect(topLeftX: 300, topLeftY: 300, width: 200, height: 200),
++        )
++        assertEquals(window.focusWindow(), true)
++        return window
++    }
++
++    func testFloatingSmartAdd_growsBothAxesAroundCenter() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize smart +50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 250)
++        assertEquals(rect?.height, 250)
++        // Center is preserved: the window grew 25pt on every side.
++        assertEquals(rect?.center, CGPoint(x: 400, y: 400))
++        assertEquals(rect?.topLeftCorner, CGPoint(x: 275, y: 275))
++    }
++
++    func testFloatingSmartSubtract_shrinksBothAxesAroundCenter() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize smart -50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 150)
++        assertEquals(rect?.height, 150)
++        assertEquals(rect?.center, CGPoint(x: 400, y: 400))
++    }
++
++    func testFloatingWidth_leavesHeightAlone() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize width +50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 250)
++        assertEquals(rect?.height, 200)
++        assertEquals(rect?.center, CGPoint(x: 400, y: 400))
++    }
++
++    func testFloatingHeight_leavesWidthAlone() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize height +50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 200)
++        assertEquals(rect?.height, 250)
++        assertEquals(rect?.center, CGPoint(x: 400, y: 400))
++    }
++
++    func testFloatingSet_appliesAbsoluteSize() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize width 400").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 400)
++        assertEquals(rect?.height, 200)
++    }
++
++    func testFloatingShrink_clampsToMinimumSize() async {
++        let window = newFloatingWindow()
++
++        // 200 - 500 would be negative; the window must stay usable.
++        await parseCommand("resize smart -500").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        let rect = try? await window.getAxRect(.nonCancellable)
++        assertEquals(rect?.width, 100)
++        assertEquals(rect?.height, 100)
++        assertEquals(rect?.center, CGPoint(x: 400, y: 400))
++    }
++
++    func testFloatingResize_updatesLastFloatingSize() async {
++        let window = newFloatingWindow()
++
++        await parseCommand("resize smart +50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++
++        // lastFloatingSize feeds tiling->floating toggles and unhideFromCorner
++        assertEquals(window.lastFloatingSize, CGSize(width: 250, height: 250))
++    }
++
++    func testFloatingResize_succeeds() async {
++        let window = newFloatingWindow()
++
++        let result = await parseCommand("resize smart +50").cmdOrDie.run(.defaultEnv, .emptyStdin)
++        assertEquals(result.exitCode.rawValue, 0)
++        assertEquals(window.isFloating, true)
++    }
+ }
+
+diff --git a/docs/aerospace-resize.adoc b/docs/aerospace-resize.adoc
+--- a/docs/aerospace-resize.adoc
++++ b/docs/aerospace-resize.adoc
+@@ -33,6 +33,17 @@
+ * If the `<number>` is prefixed with `-` then the dimension is decreased
+ * If the `<number>` is prefixed with neither `+` nor `-` then the command changes the absolute value of the dimension
+ 
++=== Floating windows
++
++Floating windows are resized directly, rather than by redistributing weights among tiling siblings.
++
++* The window's center stays fixed. Growing expands the window on all four sides, shrinking pulls it
++in on all four sides, so repeated resizes don't walk the window toward a corner.
++* A floating window has no enclosing split for `smart` to read an orientation from, so `smart` and
++`smart-opposite` both resize the window as a whole — width and height together.
++* The resulting size is clamped to the monitor's visible area, and to a 100pt minimum. Apps also
++enforce their own minimum size.
++
+ // =========================================================== Options
+ include::./util/conditional-options-header.adoc[]
+ 

--- a/patches/hyprspace/single-window-gaps.patch
+++ b/patches/hyprspace/single-window-gaps.patch
@@ -1,0 +1,117 @@
+# Summary: Adds an optional [single-window-gaps] config table used when a workspace has exactly one tiled window, letting a solo window use reduced (or zero) gaps to fill the screen. Reuses the full Gaps grammar including per-monitor arrays.
+
+diff --git a/Sources/AppBundle/config/Config.swift b/Sources/AppBundle/config/Config.swift
+--- a/Sources/AppBundle/config/Config.swift
++++ b/Sources/AppBundle/config/Config.swift
+@@ -57,6 +57,9 @@
+     var onFocusedMonitorChanged: Shell<any Command> = .empty
+ 
+     var gaps: Gaps = .zero
++    // Optional gaps override applied when a workspace has exactly one tiled window.
++    // Reuses the full Gaps grammar (inner/outer + per-monitor arrays). nil means "no override".
++    var singleWindowGaps: Gaps? = nil
+     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
+     var modes: [String: Mode] = [:]
+     var onWindowDetected: [WindowDetectedCallback] = []
+
+diff --git a/Sources/AppBundle/config/parseConfig.swift b/Sources/AppBundle/config/parseConfig.swift
+--- a/Sources/AppBundle/config/parseConfig.swift
++++ b/Sources/AppBundle/config/parseConfig.swift
+@@ -154,6 +154,7 @@
+     modeConfigRootKey: Parser(\.modes, skipParsing(Config().modes)), // Parsed manually
+ 
+     "gaps": Parser(\.gaps, parseGaps),
++    "single-window-gaps": Parser(\.singleWindowGaps, parseSingleWindowGaps),
+     "focus-follows-mouse": Parser(\.focusFollowsMouse, parseFocusFollowsMouse),
+     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
+     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
+
+diff --git a/Sources/AppBundle/config/parseGaps.swift b/Sources/AppBundle/config/parseGaps.swift
+--- a/Sources/AppBundle/config/parseGaps.swift
++++ b/Sources/AppBundle/config/parseGaps.swift
+@@ -107,6 +107,12 @@
+     parseTable(raw, .zero, gapsParser, backtrace, &c)
+ }
+ 
++// Presence of the `single-window-gaps` table enables the override. Unspecified fields default to
++// zero, so an empty `[single-window-gaps]` table means "no gaps" (single window fills the screen).
++func parseSingleWindowGaps(_ raw: OrderedJson, _ backtrace: ConfigBacktrace, _ c: inout ConfigParserContext) -> Gaps? {
++    parseGaps(raw, backtrace, &c)
++}
++
+ func parseInner(_ raw: OrderedJson, _ backtrace: ConfigBacktrace, _ c: inout ConfigParserContext) -> Gaps.Inner {
+     parseTable(raw, Gaps.Inner.zero, innerParser, backtrace, &c)
+ }
+
+diff --git a/Sources/AppBundle/layout/layoutRecursive.swift b/Sources/AppBundle/layout/layoutRecursive.swift
+--- a/Sources/AppBundle/layout/layoutRecursive.swift
++++ b/Sources/AppBundle/layout/layoutRecursive.swift
+@@ -4,7 +4,7 @@
+     @MainActor
+     func layoutWorkspace() async throws {
+         if isEffectivelyEmpty { return }
+-        let rect = workspaceMonitor.visibleRectPaddedByOuterGaps
++        let rect = workspaceMonitor.visibleRectPadded(byOuterGapsOf: effectiveGaps)
+         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
+         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
+         // But I also faced this problem in monitors horizontal configuration. ¯\_(ツ)_/¯
+@@ -63,7 +63,7 @@
+     @MainActor
+     init(_ workspace: Workspace) {
+         self.workspace = workspace
+-        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
++        self.resolvedGaps = ResolvedGaps(gaps: workspace.effectiveGaps, monitor: workspace.workspaceMonitor)
+     }
+ }
+ 
+
+diff --git a/Sources/AppBundle/model/MonitorEx.swift b/Sources/AppBundle/model/MonitorEx.swift
+--- a/Sources/AppBundle/model/MonitorEx.swift
++++ b/Sources/AppBundle/model/MonitorEx.swift
+@@ -1,8 +1,13 @@
+ extension Monitor {
+     @MainActor
+     var visibleRectPaddedByOuterGaps: Rect {
++        visibleRectPadded(byOuterGapsOf: config.gaps)
++    }
++
++    @MainActor
++    func visibleRectPadded(byOuterGapsOf gaps: Gaps) -> Rect {
+         let topLeft = visibleRect.topLeftCorner
+-        let gaps = ResolvedGaps(gaps: config.gaps, monitor: self)
++        let gaps = ResolvedGaps(gaps: gaps, monitor: self)
+         return Rect(
+             topLeftX: topLeft.x + gaps.outer.left.toDouble(),
+             topLeftY: topLeft.y + gaps.outer.top.toDouble(),
+
+diff --git a/Sources/AppBundle/tree/Workspace.swift b/Sources/AppBundle/tree/Workspace.swift
+--- a/Sources/AppBundle/tree/Workspace.swift
++++ b/Sources/AppBundle/tree/Workspace.swift
+@@ -62,7 +62,7 @@
+     }
+ 
+     override func getWeight(_ targetOrientation: Orientation) -> CGFloat {
+-        workspaceMonitor.visibleRectPaddedByOuterGaps.getDimension(targetOrientation)
++        workspaceMonitor.visibleRectPadded(byOuterGapsOf: effectiveGaps).getDimension(targetOrientation)
+     }
+ 
+     override func setWeight(_ targetOrientation: Orientation, _ newValue: CGFloat) {
+@@ -102,6 +102,18 @@
+ }
+ 
+ extension Workspace {
++    // A workspace with exactly one tiled window. Floating windows are not gap-managed, so they don't count.
++    @MainActor
++    var isSingleTiledWindow: Bool {
++        rootTilingContainer.allLeafWindowsRecursive.count == 1
++    }
++
++    // Gaps to use for this workspace's layout: the single-window override when applicable, else the normal gaps.
++    @MainActor
++    var effectiveGaps: Gaps {
++        (isSingleTiledWindow ? config.singleWindowGaps : nil) ?? config.gaps
++    }
++
+     @MainActor
+     var isVisible: Bool { visibleWorkspaceToScreenPoint.keys.contains(self) }
+     @MainActor

--- a/patches/hyprspace/single-window-gaps.patch
+++ b/patches/hyprspace/single-window-gaps.patch
@@ -64,6 +64,19 @@ diff --git a/Sources/AppBundle/layout/layoutRecursive.swift b/Sources/AppBundle/
      }
  }
  
+@@ -97,9 +97,11 @@
+ 
+     @MainActor
+     fileprivate func layoutFullscreen(_ context: LayoutContext) {
++        // Fullscreen uses the single-window gaps (if configured) so `fullscreen` matches the
++        // reduced border of a solo tiled window; `--no-outer-gaps` still means true edge-to-edge.
+         let monitorRect = noOuterGapsInFullscreen
+             ? context.workspace.workspaceMonitor.visibleRect
+-            : context.workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
++            : context.workspace.workspaceMonitor.visibleRectPadded(byOuterGapsOf: config.singleWindowGaps ?? config.gaps)
+         setAxFrame(monitorRect.topLeftCorner, CGSize(width: monitorRect.width, height: monitorRect.height))
+     }
+ }
 
 diff --git a/Sources/AppBundle/model/MonitorEx.swift b/Sources/AppBundle/model/MonitorEx.swift
 --- a/Sources/AppBundle/model/MonitorEx.swift

--- a/patches/series
+++ b/patches/series
@@ -18,3 +18,4 @@ hyprspace/opinionated-config-defaults.patch
 hyprspace/accessibility-status.patch
 hyprspace/open-terminal.patch
 hyprspace/single-window-gaps.patch
+hyprspace/center-floated-window.patch

--- a/patches/series
+++ b/patches/series
@@ -18,3 +18,4 @@ hyprspace/opinionated-config-defaults.patch
 hyprspace/accessibility-status.patch
 hyprspace/open-terminal.patch
 hyprspace/single-window-gaps.patch
+hyprspace/resize-floating-windows.patch

--- a/patches/series
+++ b/patches/series
@@ -17,3 +17,4 @@ hyprspace/canonical-config-paths.patch
 hyprspace/opinionated-config-defaults.patch
 hyprspace/accessibility-status.patch
 hyprspace/open-terminal.patch
+hyprspace/single-window-gaps.patch


### PR DESCRIPTION
## Single-window gaps

Added the option for custom padding on full screen windows and if theres only 1 window open in that workspace.

**Example usage:**

```toml
[gaps]
outer.top = 10
# ...

# Applied only when a workspace has exactly one tiled window.
# Same grammar as [gaps], including per-monitor arrays.
[single-window-gaps]
outer.top    = 0
outer.left   = 0
outer.right  = 0
outer.bottom = 0
inner.horizontal = 0
inner.vertical   = 0
```

- If there is no `[single-window-gaps]`, it defaults to the regular `[gaps]`.
- If `[single-window-gaps]` is empty, it defaults to 0 padding (full screen).
- Also wired into the `fullscreen` command.

Inspired by Hyprland's smart gaps feature.

## Floating window resize

`resize` previously errored out on floating windows. Now it works, anchored on the window's center:

- Growing expands it on all four sides.
- Shrinking pulls it in on all four sides.
- `smart` and `smart-opposite` resize both axes together, since a floating window has no enclosing split to read an orientation from.
- Sizes are clamped to the monitor's visible area and to a 100pt minimum.

Starter config now binds per-axis resizing instead of `resize smart`:

| Keybind | Action |
|---|---|
| `alt--` | shrink width |
| `alt-=` | grow width |
| `alt-_` | shrink height |
| `alt-+` | grow height |

## Center floated windows

`layout floating` now centers the window on its monitor at 62.5% of the monitor's visible area on each axis, instead of leaving it at whatever frame the tiling layout happened to give it. A window popped out of the tree now lands somewhere usable regardless of where it was tiled.

This replaces the previous behavior of restoring the window's last floating size.
